### PR TITLE
회원정보 수정 및 탈퇴

### DIFF
--- a/pension/src/main/java/com/example/pension/controller/MypageController.java
+++ b/pension/src/main/java/com/example/pension/controller/MypageController.java
@@ -2,6 +2,7 @@ package com.example.pension.controller;
 
 import com.example.pension.dto.MemberDto;
 import com.example.pension.dto.ReserveListDto;
+import com.example.pension.mappers.MypageMapper;
 import com.example.pension.service.MypageService;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,20 +22,137 @@ public class MypageController {
     @Autowired
     MypageService mypageService;
 
+    @Autowired
+    MypageMapper mypageMapper;
+
     @GetMapping("/myinfo/checkpw")
-    public String getCheckpw() {
+    public String getCheckpw(HttpSession hs, Model model) {
+        MemberDto memberDto = (MemberDto) hs.getAttribute("user");
+        model.addAttribute("member", memberDto);
+
         return "sub_pages/sub_mypage/sub_myinfo_checkpw/myinfo_checkpw.html";
     }
 
-    @GetMapping("/myinfo/sece")
-    public String getSece() {
-        return "sub_pages/sub_mypage/sub_myinfo_secession/myinfo_secession.html";
+    @PostMapping("/myinfo/checkpw")
+    @ResponseBody
+    public Map<String, Object> setCheckpw(@RequestParam int id, @RequestParam String userpw) {
+        Map<String, Object> map = new HashMap<>();
+        String alert = mypageService.checkpw(id, userpw);
+        if(alert.equals("success")) {
+            map.put("msg", "success");
+        }else if(alert.equals("failure")) {
+            map.put("msg", "failure");
+        }
+        return map;
     }
 
     @GetMapping("/myinfo/update")
-    public String getUpdate() {
+    public String getUpdate(HttpSession hs, Model model) {
+        MemberDto memberDto = (MemberDto) hs.getAttribute("user");
+        model.addAttribute("member", memberDto);
         return "sub_pages/sub_mypage/sub_myinfo_update/myinfo_update.html";
     }
+
+    @PostMapping("/changeUserid")
+    @ResponseBody
+    public Map<String, Object> setUpdateUserid(@RequestParam int id, @RequestParam String userid, HttpSession hs) {
+        Map<String, Object> map = new HashMap<>();
+        String alert = mypageService.checkUserid(userid);
+        if(alert.equals("success")) {
+            mypageMapper.setUpdateUserid(userid, id);
+            hs.invalidate();
+            map.put("msg", "success");
+        }else if(alert.equals("failure")) {
+            map.put("msg", "failure");
+        }
+        return map;
+    }
+
+    @PostMapping("/changeUserpw")
+    @ResponseBody
+    public Map<String, Object> setUpdateUserpw(@RequestParam int id, @RequestParam String userpw, @RequestParam String newUserpw, HttpSession hs) {
+        Map<String, Object> map = new HashMap<>();
+        String alert = mypageService.checkpw(id, userpw);
+        if(alert.equals("success")) {
+            mypageMapper.setUpdateUserpw(newUserpw, id);
+            hs.invalidate();
+            map.put("msg", "success");
+        }else {
+            map.put("msg", "failure");
+        }
+        return map;
+    }
+
+    @PostMapping("/changeName")
+    @ResponseBody
+    public Map<String, Object> setUpdateName(@RequestParam int id, @RequestParam String name, HttpSession hs) {
+        Map<String, Object> map = new HashMap<>();
+        mypageMapper.setUpdateName(name, id);
+        MemberDto memberDto = (MemberDto) hs.getAttribute("user");
+        memberDto.setName(name);
+        hs.setAttribute("user", memberDto);
+        map.put("msg", "success");
+        return map;
+    }
+
+    @PostMapping("/changePhone")
+    @ResponseBody
+    public Map<String, Object> setUpdatePhone(@RequestParam int id, @RequestParam String phone, HttpSession hs) {
+        Map<String, Object> map = new HashMap<>();
+        mypageMapper.setUpdatePhone(phone, id);
+        MemberDto memberDto = (MemberDto) hs.getAttribute("user");
+        memberDto.setPhone(phone);
+        hs.setAttribute("user", memberDto);
+        map.put("msg", "success");
+        return map;
+    }
+
+    @PostMapping("/changeEmail")
+    @ResponseBody
+    public Map<String, Object> setUpdateEmail(@RequestParam int id, @RequestParam String email, HttpSession hs) {
+        Map<String, Object> map = new HashMap<>();
+        mypageMapper.setUpdateEmail(email, id);
+        MemberDto memberDto = (MemberDto) hs.getAttribute("user");
+        memberDto.setEmail(email);
+        hs.setAttribute("user", memberDto);
+        map.put("msg", "success");
+        return map;
+    }
+
+    @PostMapping("/changeAddr")
+    @ResponseBody
+    public Map<String, Object> setUpdateAddr(@RequestParam int id, @RequestParam String addr, HttpSession hs) {
+        Map<String, Object> map = new HashMap<>();
+        mypageMapper.setUpdateAddr(addr, id);
+        MemberDto memberDto = (MemberDto) hs.getAttribute("user");
+        memberDto.setAddr(addr);
+        hs.setAttribute("user", memberDto);
+        map.put("msg", "success");
+        return map;
+    }
+
+    @GetMapping("/myinfo/sece")
+    public String getSece(HttpSession hs, Model model) {
+        MemberDto memberDto = (MemberDto) hs.getAttribute("user");
+        model.addAttribute("member", memberDto);
+        return "sub_pages/sub_mypage/sub_myinfo_secession/myinfo_secession.html";
+    }
+
+    @PostMapping("/secessionMember")
+    @ResponseBody
+    public Map<String, Object> setSeceMember(@RequestParam int id, HttpSession hs) {
+        Map<String, Object> map = new HashMap<>();
+        String alert = mypageService.checkReserve(id);
+        if(alert.equals("success")) {
+            mypageMapper.setSeceMember(id);
+            hs.invalidate();
+            map.put("msg", "success");
+        }else if(alert.equals("failure")) {
+            map.put("msg", "failure");
+        }
+        return map;
+    }
+
 
     @GetMapping("/reserveList")
     public String getReserveList(HttpSession hs, Model model) {

--- a/pension/src/main/java/com/example/pension/mappers/MypageMapper.java
+++ b/pension/src/main/java/com/example/pension/mappers/MypageMapper.java
@@ -26,4 +26,34 @@ public interface MypageMapper {
 
     @Select("select checkin from reserve_list where order_num = #{orderNum}")
     public LocalDate getCheckin(String orderNum);
+
+    @Select("select userpw from member where id = #{id}")
+    public String checkPw(int id);
+
+    @Select("select userid from member")
+    public List<String> checkUserid();
+
+    @Update("update member set userid = #{userid} where id = #{id}")
+    public void setUpdateUserid(String userid, int id);
+
+    @Update("update member set userpw = #{newUserpw} where id = #{id}")
+    public void setUpdateUserpw(String newUserpw, int id);
+
+    @Update("update member set name = #{name} where id = #{id}")
+    public void setUpdateName(String name, int id);
+
+    @Update("update member set phone = #{phone} where id = #{id}")
+    public void setUpdatePhone(String phone, int id);
+
+    @Update("update member set email = #{email} where id = #{id}")
+    public void setUpdateEmail(String email, int id);
+
+    @Update("update member set addr = #{addr} where id = #{id}")
+    public void setUpdateAddr(String addr, int id);
+
+    @Select("select count(*) from reserve_list where id = #{id} and checkin > curdate() and settlement_state = 1")
+    public int checkReserve(int id);
+
+    @Delete("delete from member where id = #{id}")
+    public void setSeceMember(int id);
 }

--- a/pension/src/main/java/com/example/pension/service/MypageService.java
+++ b/pension/src/main/java/com/example/pension/service/MypageService.java
@@ -14,6 +14,38 @@ public class MypageService {
     @Autowired
     MypageMapper mypageMapper;
 
+    public String checkpw(int id, String userpw) {
+        String msg = "";
+        String orgUserpw = mypageMapper.checkPw(id);
+        if(orgUserpw.equals(userpw)) {
+            msg = "success";
+        }else {
+            msg = "failure";
+        }
+        return msg;
+    }
+
+    public String checkUserid(String userid) {
+        String msg = "";
+        List<String> useridList = mypageMapper.checkUserid();
+        if(!useridList.isEmpty()) {
+            int cnt = 0;
+            for(int i=0; i<useridList.size(); i++) {
+                if(useridList.get(i).equals(userid)) {
+                    cnt += 1;
+                }
+            }
+            if(cnt > 0) {
+                msg = "failure";
+            }else {
+                msg = "success";
+            }
+        }else {
+            msg = "success";
+        }
+        return msg;
+    }
+
     public List<ReserveListDto> getReserveList(int id) {
         return mypageMapper.getReserveList(id);
     }
@@ -45,6 +77,18 @@ public class MypageService {
             msg = "success";
         }else {
             msg = "failure";
+        }
+        return msg;
+    }
+
+    public String checkReserve(int id) {
+        String msg = "";
+        int cnt = mypageMapper.checkReserve(id);
+
+        if(cnt > 0) {
+            msg = "failure";
+        }else {
+            msg = "success";
         }
         return msg;
     }

--- a/pension/src/main/resources/static/css/sub/sub_mypage/sub_myinfo_checkpw/style.css
+++ b/pension/src/main/resources/static/css/sub/sub_mypage/sub_myinfo_checkpw/style.css
@@ -220,6 +220,7 @@ td {
 }
 
 .passwd {
+    padding: 5px;
     width: 200px;
     height: 28px;
 }

--- a/pension/src/main/resources/static/css/sub/sub_mypage/sub_myinfo_update/style.css
+++ b/pension/src/main/resources/static/css/sub/sub_mypage/sub_myinfo_update/style.css
@@ -279,7 +279,7 @@ input {
 }
 
 .change_passwd_box input {
-    width: 200px;
+    width: 220px;
     height: 28px;
 }
 
@@ -288,7 +288,7 @@ input {
 }
 
 .username {
-    width: 150px;
+    width: 180px;
     height: 28px;
 }
 
@@ -306,7 +306,7 @@ input {
 }
 
 .usertell {
-    width: 200px;
+    width: 250px;
     height: 28px;
 }
 
@@ -324,7 +324,7 @@ input {
 }
 
 .useremail {
-    width: 200px;
+    width: 250px;
     height: 28px;
 }
 
@@ -342,7 +342,7 @@ input {
 }
 
 .useraddr {
-    width: 200px;
+    width: 400px;
     height: 28px;
 }
 

--- a/pension/src/main/resources/static/js/sub/sub_mypage/sub_myinfo_update/myinfo_update_exception.js
+++ b/pension/src/main/resources/static/js/sub/sub_mypage/sub_myinfo_update/myinfo_update_exception.js
@@ -1,94 +1,194 @@
-let btn_change_userid = document.querySelector("#btn_change_userid");
+let id = document.querySelector("input[name=id]");
 let userid = document.querySelector(".userid");
-let btn_change_username = document.querySelector("#btn_change_username");
-let username = document.querySelector(".username");
-let btn_change_usertell = document.querySelector("#btn_change_usertell");
-let usertell = document.querySelector(".usertell");
-let btn_change_useremail = document.querySelector("#btn_change_useremail");
-let useremail = document.querySelector(".useremail");
-let btn_change_useraddr = document.querySelector("#btn_change_useraddr");
-let useraddr = document.querySelector(".useraddr");
-
-btn_change_userid.addEventListener('click', function(e) {
-    e.preventDefault();
-
-    if(userid.value == "") {
-        alert("변경하실 아이디를 입력해 주세요.");
-        userid.focus();
-        return false;
-    }
-});
-
-btn_change_username.addEventListener('click', function(e) {
-    e.preventDefault();
-
-    if(username.value == "") {
-        alert("변경하실 이름을 입력해 주세요.");
-        username.focus();
-        return false;
-    }
-});
-
-btn_change_usertell.addEventListener('click', function(e) {
-    e.preventDefault();
-
-    if(usertell.value == "") {
-        alert("변경하실 전화번호를 입력해 주세요.");
-        usertell.focus();
-        return false;
-    }
-});
-
-btn_change_useremail.addEventListener('click', function(e) {
-    e.preventDefault();
-
-    if(useremail.value == "") {
-        alert("변경하실 이메일을 입력해 주세요.");
-        useremail.focus();
-        return false;
-    }
-});
-
-btn_change_useraddr.addEventListener('click', function(e) {
-    e.preventDefault();
-
-    if(useraddr.value == "") {
-        alert("변경하실 주소를 입력해 주세요.");
-        useraddr.focus();
-        return false;
-    }
-});
-
-let userpasswd = document.querySelector("#userpasswd");
+let name = document.querySelector(".username");
+let phone = document.querySelector(".usertell");
+let email = document.querySelector(".useremail");
+let addr = document.querySelector(".useraddr");
+let userpw = document.querySelector("#userpasswd");
 let new_userpasswd = document.querySelector("#new_userpasswd");
 let renew_userpasswd = document.querySelector("#renew_userpasswd");
 
-let passwd_change_btn = document.querySelector("#passwd_change_btn");
+function changeUserid() {
+    if(userid.value == "") {
+        alert("변경하실 아이디를 입력하세요.");
+        userid.focus();
+        return false;
+    }
 
-passwd_change_btn.addEventListener('click', function(e) {
-    e.preventDefault();
+    $.ajax({
+        type: "post",
+        url: "/mypage/changeUserid",
+        dataType: "json",
+        data:{
+            id: id.value,
+            userid: userid.value
+        },
+        success: function(result) {
+            if(result.msg == "success") {
+                alert("아이디가 변경되었습니다.\n로그인을 다시 하여 확인하세요.");
+                location.reload();
+            }else if(result.msg == "failure") {
+                alert("이미 사용중인 아이디입니다.\n다른 아이디로 입력하세요.");
+                userid.value = "";
+                location.reload();
+            }
+        }
+    });
+}
 
+function changeUserpw() {
     if(userpasswd.value == "") {
-        alert("현재 비밀번호를 입력해 주세요.");
+        alert("현재 비밀번호를 입력하세요.");
         userpasswd.focus();
         return false;
     }
     if(new_userpasswd.value == "") {
-        alert("새 비밀번호를 입력해 주세요.");
+        alert("새 비밀번호를 입력하세요.");
         new_userpasswd.focus();
         return false;
     }
     if(renew_userpasswd.value == "") {
-        alert("새 비밀번호를 다시 입력해 주세요.");
+        alert("새 비밀번호를 다시 입력하세요.");
         renew_userpasswd.focus();
         return false;
     }
 
     if(new_userpasswd.value != renew_userpasswd.value) {
-        alert("입력하신 새 비밀번호가 일치하지 않습니다.\n다시 입력해 주세요.");
+        alert("입력하신 새 비밀번호가 일치하지 않습니다.\n다시 입력하세요.");
         new_userpasswd.value = "";
         renew_userpasswd.value = "";
         new_userpasswd.focus();
         return false;
     }
-});
+
+    $.ajax({
+        type: "post",
+        url: "/mypage/changeUserpw",
+        dataType: "json",
+        data:{
+            id: id.value,
+            userpw: userpw.value,
+            newUserpw: new_userpasswd.value
+        },
+        success: function(result) {
+            if(result.msg == "success") {
+                alert("비밀번호가 변경되었습니다.\n로그인을 다시 하여 확인하세요.");
+                location.reload();
+            }else if(result.msg == "failure") {
+                alert("현재 비빌번호가 틀립니다.\n다시 입력하세요.");
+                userpw.value = "";
+                new_userpasswd.value = "";
+                renew_userpasswd.value = "";
+                location.reload();
+            }
+        }
+    });
+}
+
+function changeName() {
+    if(name.value == "") {
+        alert("변경하실 이름을 입력해 주세요.");
+        name.focus();
+        return false;
+    }
+
+    $.ajax({
+        type: "post",
+        url: "/mypage/changeName",
+        dataType: "json",
+        data:{
+            id: id.value,
+            name: name.value
+        },
+        success: function(result) {
+            if(result.msg == "success") {
+                alert("이름이 변경되었습니다.");
+                location.href = "/mypage/myinfo/update";
+            }else{
+                alert("이름 변경에 문제가 발생하였습니다.\n관리자에게 문의바랍니다.");
+                location.href = "/mypage/myinfo/update";
+            }
+        }
+    });
+}
+
+function changePhone() {
+    if(phone.value == "") {
+        alert("변경하실 전화번호를 입력해 주세요.");
+        phone.focus();
+        return false;
+    }
+
+    $.ajax({
+        type: "post",
+        url: "/mypage/changePhone",
+        dataType: "json",
+        data:{
+            id: id.value,
+            phone: phone.value
+        },
+        success: function(result) {
+            if(result.msg == "success") {
+                alert("휴대폰 번호가 변경되었습니다.");
+                location.href = "/mypage/myinfo/update";
+            }else{
+                alert("휴대폰 번호 변경에 문제가 발생하였습니다.\n관리자에게 문의바랍니다.");
+                location.href = "/mypage/myinfo/update";
+            }
+        }
+    });
+}
+
+function changeEmail() {
+    if(email.value == "") {
+        alert("변경하실 이메일을 입력해 주세요.");
+        email.focus();
+        return false;
+    }
+
+    $.ajax({
+        type: "post",
+        url: "/mypage/changeEmail",
+        dataType: "json",
+        data:{
+            id: id.value,
+            email: email.value
+        },
+        success: function(result) {
+            if(result.msg == "success") {
+                alert("이메일이 변경되었습니다.");
+                location.href = "/mypage/myinfo/update";
+            }else{
+                alert("이메일 변경에 문제가 발생하였습니다.\n관리자에게 문의바랍니다.");
+                location.href = "/mypage/myinfo/update";
+            }
+        }
+    });
+}
+
+function changeAddr() {
+    if(addr.value == "") {
+        alert("변경하실 주소를 입력해 주세요.");
+        addr.focus();
+        return false;
+    }
+
+    $.ajax({
+        type: "post",
+        url: "/mypage/changeAddr",
+        dataType: "json",
+        data:{
+            id: id.value,
+            addr: addr.value
+        },
+        success: function(result) {
+            if(result.msg == "success") {
+                alert("주소가 변경되었습니다.");
+                location.href = "/mypage/myinfo/update";
+            }else{
+                alert("주소 변경에 문제가 발생하였습니다.\n관리자에게 문의바랍니다.");
+                location.href = "/mypage/myinfo/update";
+            }
+        }
+    });
+}

--- a/pension/src/main/resources/templates/sub_pages/sub_mypage/sub_myinfo_checkpw/myinfo_checkpw.html
+++ b/pension/src/main/resources/templates/sub_pages/sub_mypage/sub_myinfo_checkpw/myinfo_checkpw.html
@@ -58,23 +58,24 @@
             </ul>
             <div class="myinfo-content">
                 <h3>회원정보 확인</h3>
-                <form action="" class="checkpw">
-                    <p>xxx님의 정보를 안전하게 보호하기 위해 비밀번호를 다시 한번 확인 합니다.</p>
+                <form class="checkpw" onsubmit="return checkpw()">
+                    <p>[[${member.name}]]님의 정보를 안전하게 보호하기 위해 비밀번호를 다시 한번 확인 합니다.</p>
                     <table>
                         <tr>
                             <th>아이디</th>
-                            <td>xxx</td>
+                            <td>[[${member.userid}]]</td>
                         </tr>
                         <tr>
                             <th>비밀번호</th>
                             <td>
-                                <input type="password" class="passwd" id="passwd" />
+                                <input type="password" name="userpw" class="passwd" id="passwd" minlength="8" maxlength="20" onpaste="return false;" oncopy="return false"/>
                             </td>
                         </tr>
                     </table>
                     <div class="btn_box">
+                        <input type="hidden" name="id" th:value="${member.id}"/>
                         <button class="btn_check" id="btn_check">확인</button>
-                        <button class="btn_cancel" ondblclick="location.href='/mypage/myinfo/checkpw'">취소</button>
+                        <button type="button" class="btn_cancel" onclick="moveMain()">취소</button>
                     </div>
                 </form>
             </div>
@@ -95,17 +96,38 @@
 
     <script>
         let passwd = document.querySelector("#passwd");
-        let btn_check = document.querySelector("#btn_check");
+        let id = document.querySelector("input[name=id]");
 
-        btn_check.addEventListener('click', function(e) {
-            e.preventDefault();
-
+        function checkpw(){
             if(passwd.value == "") {
                 alert("비밀번호를 입력해 주세요.");
                 passwd.focus();
                 return false;
             }
-        });
+
+            $.ajax({
+                type: "post",
+                url: "/mypage/myinfo/checkpw",
+                dataType: "json",
+                data: {
+                    id: id.value,
+                    userpw: passwd.value
+                },
+                success: function(result) {
+                    if(result.msg == "success") {
+                        location.href = "/mypage/myinfo/update";
+                    }else if(result.msg == "failure") {
+                        alert("비밀번호가 틀립니다.\n다시 입력해 주세요.");
+                        passwd.value = "";
+                        location.reload();
+                    }
+                }
+            });
+        }
+
+        function moveMain() {
+            location.href = "/";
+        }
     </script>
 
     <script src="../../../../static/js/header_nav.js"></script>

--- a/pension/src/main/resources/templates/sub_pages/sub_mypage/sub_myinfo_secession/myinfo_secession.html
+++ b/pension/src/main/resources/templates/sub_pages/sub_mypage/sub_myinfo_secession/myinfo_secession.html
@@ -58,7 +58,7 @@
             </ul>
             <div class="myinfo-content">
                 <h3>회원 탈퇴</h3>
-                <form>
+                <form onsubmit="return seceMember()">
                     <div class="sece_txt">
                         <h4>회원탈퇴 전, 아래 유의사항을 확인해 주시기 바랍니다.</h4>
                         <ul>
@@ -82,20 +82,21 @@
                         <ul class="sece_passwd_check">
                             <li>
                                 <label>이름 :</label>
-                                <input type="text" class="username" value="홍길동" readonly />
+                                <input type="text" class="username" th:value="${member.name}" readonly />
                             </li>
                             <li>
                                 <label>아이디 :</label>
-                                <input type="text" class="userid" value="xxx" readonly />
+                                <input type="text" class="userid" th:value="${member.userid}" readonly />
                             </li>
                             <li>
                                 <label for="passwd">비밀번호 :</label>
-                                <input type="password" id="userpasswd" class="userpasswd" value="" />
+                                <input type="password" id="userpasswd" class="userpasswd" minlength="8" maxlength="20" onpaste="return false;" oncopy="return false" />
                             </li>
                             <li>
                                 <button class="sece_btn" id="sece_btn">탈퇴하기</button>
                             </li>
                         </ul>
+                        <input type="hidden" name="id" th:value="${member.id}"/>
                     </div>
                 </form>
                 <div class="btn_box">
@@ -120,11 +121,9 @@
     <script>
         let sece_checkbox = document.querySelector("#sece_checkbox");
         let userpasswd = document.querySelector("#userpasswd");
-        let sece_btn = document.querySelector("#sece_btn");
-
-        sece_btn.addEventListener('click', function(e) {
-            e.preventDefault();
-
+        let id = document.querySelector("input[name=id]");
+        
+        function seceMember() {
             if(!sece_checkbox.checked) {
                 alert("회원탈퇴 시 처리사항에 동의해 주세요.");
                 sece_checkbox.focus();
@@ -132,10 +131,30 @@
             }
             if(userpasswd.value == "") {
                 alert("비밀번호를 입력해 주세요.");
-                sece_checkbox.focus();
+                userpasswd.focus();
                 return false;
             }
-        });
+
+            if(confirm("회원탈퇴를 하시면 복구하실 수 없습니다.\n탈퇴 하시겠습니까?")) {
+                $.ajax({
+                    type: "post",
+                    url: "/mypage/secessionMember",
+                    dataType: "json",
+                    data: {
+                        id: id.value
+                    },
+                    success: function(result) {
+                        if(result.msg == "success") {
+                            alert("회원탈퇴가 완료되었습니다.");
+                            location.href = "/";
+                        }else if(result.msg == "failure") {
+                            alert("체크인하지 않은 결제내역이 있습니다.\n취소 후 회원탈퇴 하세요.");
+                            location.href = "/mypage/reserveList";
+                        }
+                    }
+                });
+            }
+        }
     </script>
 
     <script src="../../../../static/js/header_nav.js"></script>

--- a/pension/src/main/resources/templates/sub_pages/sub_mypage/sub_myinfo_update/myinfo_update.html
+++ b/pension/src/main/resources/templates/sub_pages/sub_mypage/sub_myinfo_update/myinfo_update.html
@@ -57,16 +57,17 @@
             </ul>
             <div class="myinfo-content">
                 <h3>회원정보 수정</h3>
+                <input type="hidden" name="id" th:value="${member.id}"/>
                 <table>
                     <tr>
                         <th>아이디</th>
                         <td>
                             <p class="change_el">
-                                xxx<button class="userid_change_btn">아이디 변경</button>
+                                [[${member.userid}]]<button class="userid_change_btn">아이디 변경</button>
                             </p>
-                            <form class="userid_change">
+                            <form class="userid_change" onsubmit="return changeUserid()">
                                 <p>
-                                    <input type="text" class="userid" value="xxx"/>
+                                    <input type="text" name="userid" class="userid" th:value="${member.userid}" minlength="8" maxlength="20" placeholder="아이디는 8 ~ 20자리로 입력하세요."/>
                                     <button class="btn_change" id="btn_change_userid">변경하기</button>
                                 </p>
                             </form>
@@ -75,24 +76,24 @@
                     <tr>
                         <th>비밀번호 변경</th>
                         <td>                           
-                            <form class="userpasswd_change">
+                            <form class="userpasswd_change" onsubmit="return changeUserpw()">
                                 <table class="change_passwd_box">
                                     <tr>
                                         <td class="change_passwd_title">현재 비밀번호</td>
                                         <td>
-                                            <input type="password" class="userpasswd" id="userpasswd"/>
+                                            <input type="password" class="userpasswd" id="userpasswd" minlength="8" maxlength="20" onpaste="return false;" oncopy="return false" placeholder="현재 비밀번호를 입력하세요."/>
                                         </td>
                                     </tr>
                                     <tr>
                                         <td class="change_passwd_title">새 비밀번호</td>
                                         <td>
-                                            <input type="password" class="new_userpasswd" id="new_userpasswd"/>
+                                            <input type="password" class="new_userpasswd" id="new_userpasswd" minlength="8" maxlength="20" onpaste="return false;" oncopy="return false" placeholder="새 비밀번호를 입력하세요."/>
                                         </td>
                                     </tr>
                                     <tr>
                                         <td class="change_passwd_title">비밀번호 다시 입력</td>
                                         <td>
-                                            <input type="password" class="renew_userpasswd" id="renew_userpasswd"/>
+                                            <input type="password" class="renew_userpasswd" id="renew_userpasswd" minlength="8" maxlength="20" onpaste="return false;" oncopy="return false" placeholder="새 비밀번호를 다시 입력하세요."/>
                                         </td>
                                     </tr>
                                     <tr>
@@ -109,11 +110,11 @@
                         <th>이름</th>
                         <td>
                             <p class="change_el">
-                                홍길동<button class="username_change_btn">이름 변경</button>
+                                [[${member.name}]]<button class="username_change_btn">이름 변경</button>
                             </p>
-                            <form class="username_change">
+                            <form class="username_change" onsubmit="return changeName()">
                                 <p>
-                                    <input type="text" class="username" value="홍길동"/>
+                                    <input type="text" class="username" th:value="${member.name}" placeholder="변경할 이름을 입력하세요."/>
                                     <button class="btn_change" id="btn_change_username">변경하기</button>
                                 </p>
                             </form>
@@ -123,11 +124,11 @@
                         <th>휴대폰 번호</th>
                         <td>
                             <p class="change_el">
-                                010-1234-5678<button class="usertell_change_btn">전화번호 변경</button>
+                                [[${member.phone}]]<button class="usertell_change_btn">전화번호 변경</button>
                             </p>
-                            <form class="usertell_change">
+                            <form class="usertell_change" onsubmit="return changePhone()">
                                 <p>
-                                    <input type="text" class="usertell" value="010-1234-5678"/>
+                                    <input type="text" class="usertell" th:value="${member.phone}" placeholder="휴대폰 번호 입력 ( '-' 제외 11자리 입력 )" minlength="11" maxlength="11"/>
                                     <button class="btn_change" id="btn_change_usertell">변경하기</button>
                                 </p>
                             </form>
@@ -137,11 +138,11 @@
                         <th>이메일</th>
                         <td>
                             <p class="change_el">
-                                mail@mail.com<button class="useremail_change_btn">이메일 변경</button>
+                                [[${member.email}]]<button class="useremail_change_btn">이메일 변경</button>
                             </p>
-                            <form class="useremail_change">
+                            <form class="useremail_change" onsubmit="return changeEmail()">
                                 <p>
-                                    <input type="email" class="useremail" value="mail@mail.com"/>
+                                    <input type="email" class="useremail" th:value="${member.email}" placeholder="email@email.com"/>
                                     <button class="btn_change" id="btn_change_useremail">변경하기</button>
                                 </p>
                             </form>
@@ -151,11 +152,11 @@
                         <th>주소</th>
                         <td>
                             <p class="change_el">
-                                xxx-xxx-xxx oooooo<button class="useraddr_change_btn">주소 변경</button>
+                                [[${member.addr}]]<button class="useraddr_change_btn">주소 변경</button>
                             </p>
-                            <form class="useraddr_change">
+                            <form class="useraddr_change" onsubmit="return changeAddr()">
                                 <p>
-                                    <input type="text" class="useraddr" value="xxx-xxx-xxx oooooo"/>
+                                    <input type="text" class="useraddr" th:value="${member.addr}" placeholder="변경할 주소를 입력하세요."/>
                                     <button class="btn_change" id="btn_change_useraddr">변경하기</button>
                                 </p>
                             </form>


### PR DESCRIPTION
- 회원정보 각각 수정 (세션의 유저 정보를 가져와서)
  + 아이디 중복체크 및 비밀번호 변경 시 새 비밀번호와 일치한지 유효성 검사
  + 아이디 / 비밀번호 변경시에는 세션종료설정
  + 나머지는 그냥 변경사항 세션에 바로 적용하게 설정

- 회원탈퇴
  + 회원탈퇴 시 체크인하지 않은 결제 완료 기록이 있을 경우 탈퇴 처리하지 않고 마이페이지의 예약내역으로 이동하게 설정
