### PR TITLE
회원탈퇴 페이지 이동오류 개선

### DIFF
--- a/pension/src/main/java/com/example/pension/controller/MypageController.java
+++ b/pension/src/main/java/com/example/pension/controller/MypageController.java
@@ -144,8 +144,9 @@ public class MypageController {
         Map<String, Object> map = new HashMap<>();
         String alert = mypageService.checkReserve(id);
         if(alert.equals("success")) {
-            mypageMapper.setSeceMember(id);
             hs.invalidate();
+            mypageMapper.deleteReserveMember(id);
+            mypageMapper.setSeceMember(id);
             map.put("msg", "success");
         }else if(alert.equals("failure")) {
             map.put("msg", "failure");

--- a/pension/src/main/java/com/example/pension/controller/PensionController.java
+++ b/pension/src/main/java/com/example/pension/controller/PensionController.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 @Controller
 public class PensionController {
 
-    @GetMapping("")
+    @GetMapping("/")
     public String getMain() {
         return "index.html";
     }

--- a/pension/src/main/java/com/example/pension/mappers/MypageMapper.java
+++ b/pension/src/main/java/com/example/pension/mappers/MypageMapper.java
@@ -56,4 +56,7 @@ public interface MypageMapper {
 
     @Delete("delete from member where id = #{id}")
     public void setSeceMember(int id);
+
+    @Delete("delete from reserve_list where id = #{id}")
+    public void deleteReserveMember(int id);
 }

--- a/pension/src/main/resources/templates/sub_pages/sub_mypage/sub_myinfo_secession/myinfo_secession.html
+++ b/pension/src/main/resources/templates/sub_pages/sub_mypage/sub_myinfo_secession/myinfo_secession.html
@@ -89,7 +89,7 @@
                                 <input type="text" class="userid" th:value="${member.userid}" readonly />
                             </li>
                             <li>
-                                <label for="passwd">비밀번호 :</label>
+                                <label for="userpasswd">비밀번호 :</label>
                                 <input type="password" id="userpasswd" class="userpasswd" minlength="8" maxlength="20" onpaste="return false;" oncopy="return false" />
                             </li>
                             <li>
@@ -144,12 +144,13 @@
                         id: id.value
                     },
                     success: function(result) {
+                        console.log(result.msg);
                         if(result.msg == "success") {
-                            alert("회원탈퇴가 완료되었습니다.");
                             location.href = "/";
+                            alert("회원탈퇴가 완료되었습니다.");
                         }else if(result.msg == "failure") {
-                            alert("체크인하지 않은 결제내역이 있습니다.\n취소 후 회원탈퇴 하세요.");
                             location.href = "/mypage/reserveList";
+                            alert("체크인하지 않은 결제내역이 있습니다.\n취소 후 회원탈퇴 하세요.");
                         }
                     }
                 });


### PR DESCRIPTION
- 탈퇴 시 오류(1)
  + 체크인 날짜가 오늘 날짜 이전일 경우 예약리스트에서 먼저 삭제 후 회원정보 삭제 진행(추가)
- 탈퇴 시 오류(2)
  + 세션값 때문에 페이지 이동이 안됐었는데,
      원인 : 기존 회원 정보 삭제 후 세션 종료를 진행했음
      개선 : 세션 종료전 회원 정보를 삭제해 버리면 세션에 적용될 회원 정보가 사라지기 때문에 오류가 발생하였다 생각하고 세션
                을 먼저 종료 후 회원 정보 삭제 진행