### PR TITLE
페이지 새로고침 오류 수정

### DIFF
--- a/pension/src/main/java/com/example/pension/mappers/MypageMapper.java
+++ b/pension/src/main/java/com/example/pension/mappers/MypageMapper.java
@@ -51,7 +51,7 @@ public interface MypageMapper {
     @Update("update member set addr = #{addr} where id = #{id}")
     public void setUpdateAddr(String addr, int id);
 
-    @Select("select count(*) from reserve_list where id = #{id} and checkin > curdate() and settlement_state = 1")
+    @Select("select count(*) from reserve_list where id = #{id} and checkout > curdate() and settlement_state = 1")
     public int checkReserve(int id);
 
     @Delete("delete from member where id = #{id}")

--- a/pension/src/main/resources/static/js/sub/sub_mypage/sub_myinfo_update/myinfo_update_exception.js
+++ b/pension/src/main/resources/static/js/sub/sub_mypage/sub_myinfo_update/myinfo_update_exception.js
@@ -25,12 +25,12 @@ function changeUserid() {
         },
         success: function(result) {
             if(result.msg == "success") {
+                location.href = "/mypage/myinfo/checkpw";
                 alert("아이디가 변경되었습니다.\n로그인을 다시 하여 확인하세요.");
-                location.reload();
             }else if(result.msg == "failure") {
+                location.reload();
                 alert("이미 사용중인 아이디입니다.\n다른 아이디로 입력하세요.");
                 userid.value = "";
-                location.reload();
             }
         }
     });
@@ -72,14 +72,14 @@ function changeUserpw() {
         },
         success: function(result) {
             if(result.msg == "success") {
+                location.href = "/mypage/myinfo/checkpw";
                 alert("비밀번호가 변경되었습니다.\n로그인을 다시 하여 확인하세요.");
-                location.reload();
             }else if(result.msg == "failure") {
+                location.reload();
                 alert("현재 비빌번호가 틀립니다.\n다시 입력하세요.");
                 userpw.value = "";
                 new_userpasswd.value = "";
                 renew_userpasswd.value = "";
-                location.reload();
             }
         }
     });
@@ -102,11 +102,11 @@ function changeName() {
         },
         success: function(result) {
             if(result.msg == "success") {
+                location.href = "/mypage/myinfo/update";
                 alert("이름이 변경되었습니다.");
-                location.href = "/mypage/myinfo/update";
             }else{
-                alert("이름 변경에 문제가 발생하였습니다.\n관리자에게 문의바랍니다.");
                 location.href = "/mypage/myinfo/update";
+                alert("이름 변경에 문제가 발생하였습니다.\n관리자에게 문의바랍니다.");
             }
         }
     });
@@ -129,11 +129,11 @@ function changePhone() {
         },
         success: function(result) {
             if(result.msg == "success") {
+                location.href = "/mypage/myinfo/update";
                 alert("휴대폰 번호가 변경되었습니다.");
-                location.href = "/mypage/myinfo/update";
             }else{
-                alert("휴대폰 번호 변경에 문제가 발생하였습니다.\n관리자에게 문의바랍니다.");
                 location.href = "/mypage/myinfo/update";
+                alert("휴대폰 번호 변경에 문제가 발생하였습니다.\n관리자에게 문의바랍니다.");
             }
         }
     });
@@ -156,11 +156,11 @@ function changeEmail() {
         },
         success: function(result) {
             if(result.msg == "success") {
+                location.href = "/mypage/myinfo/update";
                 alert("이메일이 변경되었습니다.");
-                location.href = "/mypage/myinfo/update";
             }else{
-                alert("이메일 변경에 문제가 발생하였습니다.\n관리자에게 문의바랍니다.");
                 location.href = "/mypage/myinfo/update";
+                alert("이메일 변경에 문제가 발생하였습니다.\n관리자에게 문의바랍니다.");
             }
         }
     });
@@ -183,11 +183,11 @@ function changeAddr() {
         },
         success: function(result) {
             if(result.msg == "success") {
+                location.href = "/mypage/myinfo/update";
                 alert("주소가 변경되었습니다.");
-                location.href = "/mypage/myinfo/update";
             }else{
-                alert("주소 변경에 문제가 발생하였습니다.\n관리자에게 문의바랍니다.");
                 location.href = "/mypage/myinfo/update";
+                alert("주소 변경에 문제가 발생하였습니다.\n관리자에게 문의바랍니다.");
             }
         }
     });

--- a/pension/src/main/resources/templates/sub_pages/sub_mypage/sub_myinfo_secession/myinfo_secession.html
+++ b/pension/src/main/resources/templates/sub_pages/sub_mypage/sub_myinfo_secession/myinfo_secession.html
@@ -150,7 +150,7 @@
                             alert("회원탈퇴가 완료되었습니다.");
                         }else if(result.msg == "failure") {
                             location.href = "/mypage/reserveList";
-                            alert("체크인하지 않은 결제내역이 있습니다.\n취소 후 회원탈퇴 하세요.");
+                            alert("체크인 전 이거나,\n체크인아웃이 완료되지 않은 결제내역이 있습니다.\n체크인 전이라면 결제취소 후,\n체크인 했다면 체크아웃 후 회원탈퇴 하세요.");
                         }
                     }
                 });


### PR DESCRIPTION
- 회원탈퇴 시 체크인 했을경우를 생각하여 결제완료된 객실이 있을 경우 체크아웃 이후에 탈퇴 가능하게 설정
- 회원정보 수정에서 새로고침 오류로 인해 새로고침을 눌러야 회원정보가 바뀌기 때문에 코드의 순서를 변경하여 바로 로딩되게 설정