### PR TITLE
예외처리 및 사용자 예약내역 삭제 시 delete -> update

### DIFF
--- a/pension/src/main/java/com/example/pension/controller/MypageController.java
+++ b/pension/src/main/java/com/example/pension/controller/MypageController.java
@@ -169,11 +169,11 @@ public class MypageController {
         return "sub_pages/sub_mypage/sub_reserve_list/reserve_list.html";
     }
 
-    @PostMapping("/deleteReserveList")
+    @PostMapping("/hiddenReserveList")
     @ResponseBody
     public Map<String, Object> deleteReserveList(@RequestParam String orderNum) {
         Map<String, Object> map = new HashMap<>();
-        String check = mypageService.deleteReserveList(orderNum);
+        String check = mypageService.hiddenReserveList(orderNum);
         if(check.equals("failure")) {
             map.put("msg", "failure");
         }else if(check.equals("success")) {

--- a/pension/src/main/java/com/example/pension/dto/ReserveListDto.java
+++ b/pension/src/main/java/com/example/pension/dto/ReserveListDto.java
@@ -17,6 +17,7 @@ public class ReserveListDto {
     private LocalDateTime settlementTime;
     private int settlementState;
     private int dayNight;
+    private int hiddenReserve;
 
     public int getId() {
         return id;
@@ -120,6 +121,14 @@ public class ReserveListDto {
 
     public void setDayNight(int dayNight) {
         this.dayNight = dayNight;
+    }
+
+    public int getHiddenReserve() {
+        return hiddenReserve;
+    }
+
+    public void setHiddenReserve(int hiddenReserve) {
+        this.hiddenReserve = hiddenReserve;
     }
 
     @Override

--- a/pension/src/main/java/com/example/pension/mappers/MypageMapper.java
+++ b/pension/src/main/java/com/example/pension/mappers/MypageMapper.java
@@ -12,14 +12,14 @@ import java.util.List;
 @Mapper
 public interface MypageMapper {
 
-    @Select("select * from reserve_list where id = #{id}")
+    @Select("select * from reserve_list where id = #{id} and hidden_reserve = 0")
     public List<ReserveListDto> getReserveList(int id);
 
     @Select("select settlement_state from reserve_list where order_num = #{orderNum}")
     public int getSettlementState(String orderNum);
 
-    @Delete("delete from reserve_list where order_num = #{orderNum}")
-    public void deleteReserveList(String orderNum);
+    @Update("update reserve_list set hidden_reserve = 1 where order_num = #{orderNum}")
+    public void hiddenReserveList(String orderNum);
 
     @Update("update reserve_list set settlement_state = 0 where order_num = #{orderNum}")
     public void cancelReserve(String orderNum);

--- a/pension/src/main/java/com/example/pension/mappers/ReserveMapper.java
+++ b/pension/src/main/java/com/example/pension/mappers/ReserveMapper.java
@@ -19,9 +19,9 @@ public interface ReserveMapper {
     @Select("select min_person from room_list where room_name = #{roomName}")
     public int reservePerson(String roomNum);
 
-    @Insert("insert into reserve_list values(#{id}, #{orderNum}, #{checkin}, #{checkout}, #{person}, #{reserveEmail}, #{reserveName}, #{reserveTell}, #{payMoney}, #{roomName}, now(), #{settlementState}, #{dayNight})")
+    @Insert("insert into reserve_list values(#{id}, #{orderNum}, #{checkin}, #{checkout}, #{person}, #{reserveEmail}, #{reserveName}, #{reserveTell}, #{payMoney}, #{roomName}, now(), #{settlementState}, #{dayNight}, #{hiddenReserve})")
     public void setReserveList(ReserveListDto reserveListDto);
 
-    @Select("select * from reserve_list where checkin >= curdate() and id = #{id} and settlement_state = 1")
+    @Select("select * from reserve_list where checkin >= curdate() and id = #{id} and settlement_state = 1 and hidden_reserve = 0")
     public List<ReserveListDto> getReserveList(int id);
 }

--- a/pension/src/main/java/com/example/pension/service/MypageService.java
+++ b/pension/src/main/java/com/example/pension/service/MypageService.java
@@ -50,20 +50,20 @@ public class MypageService {
         return mypageMapper.getReserveList(id);
     }
 
-    public String deleteReserveList(String orderNum) {
+    public String hiddenReserveList(String orderNum) {
         String msg = "";
         LocalDate checkin = mypageMapper.getCheckin(orderNum);
         LocalDate now = LocalDate.now();
         int state = mypageMapper.getSettlementState(orderNum);
 
         if(checkin.isBefore(now)) {
-            mypageMapper.deleteReserveList(orderNum);
+            mypageMapper.hiddenReserveList(orderNum);
             msg = "success";
         }else {
             if(state == 1) {
                 msg = "failure";
             }else {
-                mypageMapper.deleteReserveList(orderNum);
+                mypageMapper.hiddenReserveList(orderNum);
                 msg = "success";
             }
         }

--- a/pension/src/main/java/com/example/pension/service/ReserveService.java
+++ b/pension/src/main/java/com/example/pension/service/ReserveService.java
@@ -39,6 +39,7 @@ public class ReserveService {
 
     public void setReserveList(ReserveListDto reserveListDto) {
         reserveListDto.setSettlementState(1);
+        reserveListDto.setHiddenReserve(0);
 
         reserveMapper.setReserveList(reserveListDto);
     }

--- a/pension/src/main/resources/static/css/sub/sub_mypage/sub_myinfo_update/style.css
+++ b/pension/src/main/resources/static/css/sub/sub_mypage/sub_myinfo_update/style.css
@@ -224,10 +224,6 @@ button {
     border-radius: 3px;
 }
 
-.userid_change_btn {
-    margin-left: 20px;
-}
-
 form {
     padding: 10px 10px;
     border: 1px solid #ccc;
@@ -238,25 +234,11 @@ input {
     padding: 2px 6px;
 }
 
-.userid {
-    width: 250px;
-    height: 28px;
-}
-
 .btn_change {
     margin-left: 15px;
     border: 1px solid #555;
     background-color: rgb(92, 132, 241);
     color: #fff;
-}
-
-.userid_change {
-    margin-top: 15px;
-    display: none;
-}
-
-.userid_box {
-    display: block;
 }
 
 .userpasswd_change {

--- a/pension/src/main/resources/static/css/sub/sub_reserve/sub_check_room/style.css
+++ b/pension/src/main/resources/static/css/sub/sub_reserve/sub_check_room/style.css
@@ -337,6 +337,15 @@ button {
     display: block;
 }
 
+.alert-empty {
+    width: 100%;
+}
+
+.alert-empty h1 {
+    margin-top: 80px;
+    text-align: center;
+}
+
 .room-list {
     margin-bottom: 0;
     margin-top: 80px;
@@ -346,10 +355,6 @@ button {
     grid-template-columns: repeat(2, 1fr);
     column-gap: 10%;
     row-gap: 20px
-}
-
-.room-list h1 {
-    margin: 0 auto;
 }
 
 .room-list img {

--- a/pension/src/main/resources/static/js/sub/sub_mypage/sub_myinfo_update/myinfo_update.js
+++ b/pension/src/main/resources/static/js/sub/sub_mypage/sub_myinfo_update/myinfo_update.js
@@ -1,21 +1,3 @@
-let userid_change_btn = document.querySelector(".userid_change_btn");
-let userid_change = document.querySelector(".userid_change");
-
-userid_change_btn.addEventListener('click', function(e) {
-    e.preventDefault();
-
-    userid_change.classList.toggle("userid_box");
-    if(userid_change.classList.contains("userid_box")){
-        userid_change_btn.innerText = "아이디 변경 취소";
-        userid_change_btn.style.backgroundColor = "#999";
-        userid_change_btn.style.color = "#fff";
-    }else {
-        userid_change_btn.innerText = "아이디 변경";
-        userid_change_btn.style.backgroundColor = "#eee";
-        userid_change_btn.style.color = "#555";
-    }
-});
-
 let username_change_btn = document.querySelector(".username_change_btn");
 let username_change = document.querySelector(".username_change");
 

--- a/pension/src/main/resources/static/js/sub/sub_mypage/sub_myinfo_update/myinfo_update_exception.js
+++ b/pension/src/main/resources/static/js/sub/sub_mypage/sub_myinfo_update/myinfo_update_exception.js
@@ -1,5 +1,3 @@
-let id = document.querySelector("input[name=id]");
-let userid = document.querySelector(".userid");
 let name = document.querySelector(".username");
 let phone = document.querySelector(".usertell");
 let email = document.querySelector(".useremail");
@@ -8,38 +6,10 @@ let userpw = document.querySelector("#userpasswd");
 let new_userpasswd = document.querySelector("#new_userpasswd");
 let renew_userpasswd = document.querySelector("#renew_userpasswd");
 
-function changeUserid() {
-    if(userid.value == "") {
-        alert("변경하실 아이디를 입력하세요.");
-        userid.focus();
-        return false;
-    }
-
-    $.ajax({
-        type: "post",
-        url: "/mypage/changeUserid",
-        dataType: "json",
-        data:{
-            id: id.value,
-            userid: userid.value
-        },
-        success: function(result) {
-            if(result.msg == "success") {
-                location.href = "/mypage/myinfo/checkpw";
-                alert("아이디가 변경되었습니다.\n로그인을 다시 하여 확인하세요.");
-            }else if(result.msg == "failure") {
-                location.reload();
-                alert("이미 사용중인 아이디입니다.\n다른 아이디로 입력하세요.");
-                userid.value = "";
-            }
-        }
-    });
-}
-
 function changeUserpw() {
-    if(userpasswd.value == "") {
+    if(userpw.value == "") {
         alert("현재 비밀번호를 입력하세요.");
-        userpasswd.focus();
+        userpw.focus();
         return false;
     }
     if(new_userpasswd.value == "") {
@@ -58,6 +28,15 @@ function changeUserpw() {
         new_userpasswd.value = "";
         renew_userpasswd.value = "";
         new_userpasswd.focus();
+        return false;
+    }
+    
+    if(new_userpasswd.value == userpw.value) {
+        alert("현재 사용중인 비밀번호입니다.\n새로운 비밀번호로 입력하세요.");
+        userpw.value = "";
+        new_userpasswd.value = "";
+        renew_userpasswd.value = "";
+        userpw.focus();
         return false;
     }
 

--- a/pension/src/main/resources/static/sql/seongyoung/reserve.sql
+++ b/pension/src/main/resources/static/sql/seongyoung/reserve.sql
@@ -12,6 +12,7 @@ create table reserve_list(
 	settlement_time datetime not null,
 	settlement_state int not null,
 	day_night int not null,
+	hidden_reserve int(1) not null,
 	foreign key(id) references member(id) ON UPDATE cascade ON DELETE restrict
 );
 

--- a/pension/src/main/resources/templates/sub_pages/sub_mypage/sub_myinfo_checkpw/myinfo_checkpw.html
+++ b/pension/src/main/resources/templates/sub_pages/sub_mypage/sub_myinfo_checkpw/myinfo_checkpw.html
@@ -68,7 +68,7 @@
                         <tr>
                             <th>비밀번호</th>
                             <td>
-                                <input type="password" name="userpw" class="passwd" id="passwd" minlength="8" maxlength="20" onpaste="return false;" oncopy="return false"/>
+                                <input type="password" name="userpw" class="passwd" id="passwd" onpaste="return false;" oncopy="return false"/>
                             </td>
                         </tr>
                     </table>

--- a/pension/src/main/resources/templates/sub_pages/sub_mypage/sub_myinfo_update/myinfo_update.html
+++ b/pension/src/main/resources/templates/sub_pages/sub_mypage/sub_myinfo_update/myinfo_update.html
@@ -63,14 +63,8 @@
                         <th>아이디</th>
                         <td>
                             <p class="change_el">
-                                [[${member.userid}]]<button class="userid_change_btn">아이디 변경</button>
+                                [[${member.userid}]]
                             </p>
-                            <form class="userid_change" onsubmit="return changeUserid()">
-                                <p>
-                                    <input type="text" name="userid" class="userid" th:value="${member.userid}" minlength="8" maxlength="20" placeholder="아이디는 8 ~ 20자리로 입력하세요."/>
-                                    <button class="btn_change" id="btn_change_userid">변경하기</button>
-                                </p>
-                            </form>
                         </td>
                     </tr>
                     <tr>
@@ -81,7 +75,7 @@
                                     <tr>
                                         <td class="change_passwd_title">현재 비밀번호</td>
                                         <td>
-                                            <input type="password" class="userpasswd" id="userpasswd" minlength="8" maxlength="20" onpaste="return false;" oncopy="return false" placeholder="현재 비밀번호를 입력하세요."/>
+                                            <input type="password" class="userpasswd" id="userpasswd" onpaste="return false;" oncopy="return false" placeholder="현재 비밀번호를 입력하세요."/>
                                         </td>
                                     </tr>
                                     <tr>

--- a/pension/src/main/resources/templates/sub_pages/sub_mypage/sub_reserve_list/reserve_list.html
+++ b/pension/src/main/resources/templates/sub_pages/sub_mypage/sub_reserve_list/reserve_list.html
@@ -117,14 +117,14 @@
                                     <th:block th:if="${rl.settlementState eq 1}">
                                         <th:block th:if="${rl.checkin >= nowDate}">
                                             <button type="button" class="btn cancel-btn" th:onclick="cancelReserve([[${rl.orderNum}]])">결제취소</button>
-                                            <button type="button" class="btn delete-btn" th:onclick="deleteList([[${rl.orderNum}]])">예약내역 삭제</button>
+                                            <button type="button" class="btn delete-btn" th:onclick="hiddenList([[${rl.orderNum}]])">예약내역 삭제</button>
                                         </th:block>
                                         <th:block th:unless="${rl.checkin >= nowDate}">
-                                            <button type="button" class="btn delete-btn" th:onclick="deleteList([[${rl.orderNum}]])">예약내역 삭제</button>
+                                            <button type="button" class="btn delete-btn" th:onclick="hiddenList([[${rl.orderNum}]])">예약내역 삭제</button>
                                         </th:block>
                                     </th:block>
                                     <th:block th:unless="${rl.settlementState eq 1}">
-                                        <button type="button" class="btn delete-btn" th:onclick="deleteList([[${rl.orderNum}]])">예약내역 삭제</button>
+                                        <button type="button" class="btn delete-btn" th:onclick="hiddenList([[${rl.orderNum}]])">예약내역 삭제</button>
                                     </th:block>
                                 </td>
                             </tr>
@@ -148,11 +148,11 @@
     </div>
 
     <script>
-        function deleteList(orderNum) {
+        function hiddenList(orderNum) {
             if(confirm("예약내역을 삭제하면 복구하실 수 없습니다.\n삭제하시겠습니까?")) {
                 $.ajax({
                     type: "post",
-                    url: "/mypage/deleteReserveList",
+                    url: "/mypage/hiddenReserveList",
                     dataType: "json",
                     data: {orderNum: orderNum},
                     success: function(result) {

--- a/pension/src/main/resources/templates/sub_pages/sub_reserve/sub_check_room/check_room.html
+++ b/pension/src/main/resources/templates/sub_pages/sub_reserve/sub_check_room/check_room.html
@@ -118,6 +118,9 @@
                     </li>
                   </ul>
                 </div>
+                <div class="alert-empty">
+                  
+                </div>
                 <ul class="room-list">
                   
                 </ul>
@@ -244,10 +247,13 @@
                             </form>
                           </li>`;
               });
+              document.querySelector(".alert-empty").innerHTML = "";
+              document.querySelector(".room-list").innerHTML = output;
             }else {
               output += `<h1>예약가능한 객실이 없습니다.</h1>`
+              document.querySelector(".room-list").innerHTML = "";
+              document.querySelector(".alert-empty").innerHTML = output;
             }
-            document.querySelector(".room-list").innerHTML = output;
           }
         });
       });


### PR DESCRIPTION
- 현재 사용중인 비밀번호로 변경할 경우 현재 사용중인 비밀번호라고 예외처리
- 기존에는 사용자가 예약내역을 삭제하면 관리자도 확인할 수 없게 데이터 자체가 삭제되었는데, 그렇게 하면 관리자가 확인할 기록이 사라지기 때문에 이를 단순 delete가 아닌 update를 이용하여 하나의 상태값을 테이블 컬럼으로 추가하여 update로 보여질지 아닐지 표시하게 설정하였음
- 마지막으로 객실조회 창에서 grid로 표시하여 예약가능한 객실이 없다는 문구가 잘려 표현되는 오류를 html, css 수정을 통해 해결